### PR TITLE
Changes routing for categories

### DIFF
--- a/routes/rsvp.js
+++ b/routes/rsvp.js
@@ -1,0 +1,9 @@
+const express = require('express')
+const rsvpController = require('../controllers/rsvp')
+const router = express.Router()
+
+router.post('/rsvp', rsvpController.add)
+
+router.get('/rsvp/user', rsvpController.getByUser)
+
+router.module.exports = router

--- a/routes/user.js
+++ b/routes/user.js
@@ -6,6 +6,6 @@ router.post('/register', userController.register)
 
 router.post('/login', userController.login)
 
-router.get('/logout' , userController.logout)
+router.get('/logout', userController.logout)
 
 module.exports = router


### PR DESCRIPTION
In order to get events by category in the first place, first we need the category id, which is why we will need to place the id on the route